### PR TITLE
removed unused interface

### DIFF
--- a/portfolio-app/src/sections/about_section.tsx
+++ b/portfolio-app/src/sections/about_section.tsx
@@ -5,12 +5,6 @@ import hightlight2Image from "../assets/sections_assets/about_section_assets/ai-
 import highlight3Image from "../assets/sections_assets/about_section_assets/full-stack.webp";
 import highlight4Image from "../assets/sections_assets/about_section_assets/problem-solving.webp";
 
-interface HighlightCard {
-  image: string;
-  heading: string;
-  subtext: string;
-}
-
 const aboutContent = {
   summary:
     "Pushing the boundaries of ***full-stack development*** and ***AI***, crafting ***innovative solutions*** that drive impact.",


### PR DESCRIPTION
This pull request removes the `HighlightCard` interface from the `about_section.tsx` file, simplifying the code by eliminating unused or unnecessary definitions.

Key change:

* [`portfolio-app/src/sections/about_section.tsx`](diffhunk://#diff-97a8c9683e625b6b8a86c6cc5b25ab94583d40d053a3b9555bdf2e8f9d1e6491L8-L13): Removed the `HighlightCard` interface, which defined properties for `image`, `heading`, and `subtext`, as it is no longer used in the file.